### PR TITLE
Update ghostly link and download script

### DIFF
--- a/scripts/common/downloader.sh
+++ b/scripts/common/downloader.sh
@@ -78,6 +78,16 @@ download_riivolution_patch () {
 			exit 21
 		;;
 
+        *mediafire* )
+			x=6
+			echo "can not download from MediaFire, download manually from:
+
+	${DOWNLOAD_LINK}
+"
+
+			exit 21
+		;;
+
 		"" )
 			echo "no download link for ${GAMENAME} available."
             download_riivolution_failed

--- a/scripts/nsmbw/ghostlysuperghostbooswii.sh
+++ b/scripts/nsmbw/ghostlysuperghostbooswii.sh
@@ -2,7 +2,7 @@
 
 WORKDIR=nsmb.d
 DOL=${WORKDIR}/sys/main.dol
-DOWNLOAD_LINK="http://download858.mediafire.com/d8ceavb0izvg/vf7p9pu8bqxohuo/GSGBW+v1.0.2.zip"
+DOWNLOAD_LINK="https://www.mediafire.com/file/vf7p9pu8bqxohuo/GSGBW_v1.0.2.zip/file"
 RIIVOLUTION_ZIP="GSGBW v1.0.2.zip"
 RIIVOLUTION_DIR="GSGBW/Ghostly"
 GAMENAME="Ghostly Super Ghost Boos. Wii"


### PR DESCRIPTION
Provide a "semi-direct" link to download ghostly from MediaFire.
(we have just to open it in browser)
The download script alert now the user that auto download from MediaFire is not possible from script.